### PR TITLE
Add init Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Misc.
-EXTRAS=nojhan/liquidprompt.git altercation/solarized.git tonsky/FiraCode.git
-SHELL=/bin/bash
-VIM_SPF13_HOME=$$HOME/.spf13-vim-3
-SRC_DIR=/usr/local/src
+EXTRAS = nojhan/liquidprompt.git altercation/solarized.git tonsky/FiraCode.git
+SHELL = /bin/bash
+VIM_SPF13_HOME = $$HOME/.spf13-vim-3
+SRC_DIR = /usr/local/src
+OSX_RESTORE_DIR = $(SRC_DIR)/osx-restore
 
 default: setup
 
@@ -15,7 +16,7 @@ help: # Display help
 bash: ## Setup Bash
 	@ls bash | xargs -I {} ln -sf ${PWD}/bash/{} ~/.{}
 
-brew: ## Install packages with Brew
+brew: init ## Install packages with Brew
 	@bash setup/brew.sh
 	@ln -sf ${PWD}/bin/brew-cask-update.sh /usr/local/bin/brew-cask-update
 
@@ -37,6 +38,11 @@ git: ## Configure git
 	@git config --global alias.lsg 'log --pretty=format:"%C(yellow)%h\ %Cgreen%ad%Cred%d\ %Creset%s%Cblue\ [%cn]" --decorate --date=short --graph'
 	@git config --global core.editor vim
 
+init: ## Initialize the setup
+	@brew --version || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	@brew update && brew install git
+	@git -C "${OSX_RESTORE_DIR}" pull  || git clone https://github.com/rgreinho/osx-restore.git "${OSX_RESTORE_DIR}"
+
 vim: ## Install and configure Vim SPF13
 	@{ \
 		if [ -d "$(VIM_SPF13_HOME)/" ]; then \
@@ -50,7 +56,6 @@ vim: ## Install and configure Vim SPF13
 		fi \
 	}
 
-
 setup: bash brew editorconfig extras git vim ## Full setup
 
-.PHONY: bash brew editorconfig extras git setup vim
+.PHONY: bash brew editorconfig extras git init setup vim

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This is just a small repository to help me reinstall my mac faster.
 ## Usage
 
 Clone this repository into `/usr/local/src` and run `make`.
+
+or 
+
+```
+cd $(mktemp -d) \
+&& wget https://raw.githubusercontent.com/rgreinho/osx-restore/master/Makefile \
+&& make init
+```

--- a/setup/brew.sh
+++ b/setup/brew.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Install brew.
-brew --version || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
 # Get Homebrew-cask.
 brew tap caskroom/cask
 


### PR DESCRIPTION
The `init` Makefile target solves the chicken and egg issue where you
need to have `git` to clone this repository but need to have `brew` to
install `git`.