### PR TITLE
Simplify bootstrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,7 @@ git: ## Configure git
 	@git config --global core.editor vim
 
 init: ## Initialize the setup
-	@xcode-select --install 2>/dev/null || True
-	@brew --version || /usr/bin/ruby -e "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-	@brew update && brew install git
-	@sudo mkdir -p $(SRC_DIR) && chown $${USER} $(SRC_DIR)
-	@git -C "$(OSX_RESTORE_DIR)" pull || git clone https://github.com/rgreinho/osx-restore.git "$(OSX_RESTORE_DIR)"
+	@bash setup/bootstrap.sh
 
 vim: ## Install and configure Vim SPF13
 	@{ \

--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ This is just a small repository to help me reinstall my mac faster.
 
 Clone this repository into `/usr/local/src` and run `make`.
 
-or 
+or
 
 ```
-cd $(mktemp -d) \
-&& curl -O https://raw.githubusercontent.com/rgreinho/osx-restore/master/Makefile \
-&& make init \
-&& cd /usr/local/src/osx-restore \
-&& make
+bash <(curl -fsSL https://raw.githubusercontent.com/rgreinho/osx-restore/master/setup/bootstrap.sh)
 ```

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Define variables
+SRC_DIR=/usr/local/src
+OSX_RESTORE_DIR=${SRC_DIR}/osx-restore
+
+xcode-select --install 2>/dev/null || True
+brew --version || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew update && brew install git
+sudo mkdir -p "${SRC_DIR}" && chown "${USER}" "${SRC_DIR}"
+git -C "${OSX_RESTORE_DIR}" pull || git clone https://github.com/rgreinho/osx-restore.git "${OSX_RESTORE_DIR}"

--- a/setup/brew.sh
+++ b/setup/brew.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Define variables.
+: ${OSXR_BREW_FORCE_INSTALL:=0}
+
 # Get Homebrew-cask.
 brew tap caskroom/cask
 
@@ -8,7 +11,7 @@ brew tap caskroom/cask
 brew tap buo/cask-upgrade
 
 # Install packages.
-if ! brew update; then
+if ! brew update || [ "${OSXR_BREW_FORCE_INSTALL}" -eq 1 ] ;then
   brew install \
     bash-completion \
     chromedriver \
@@ -50,7 +53,7 @@ if ! brew update; then
     Caskroom/cask/sweet-home3d \
     Caskroom/cask/vagrant \
     Caskroom/cask/virtualbox \
-    Caskroom/cask/virtualbox-extension-pack
+    Caskroom/cask/virtualbox-extension-pack \
     Caskroom/cask/vlc
 
   # Clean up.


### PR DESCRIPTION
This patch reduces the bootstrapping process to only one command.

Drive-by:
* Fix the `brew.sh` script